### PR TITLE
Set read-only mode in playback

### DIFF
--- a/src/configurableTL.js
+++ b/src/configurableTL.js
@@ -572,7 +572,7 @@ function initializeElements(timeline_container, data, duration, width, height, u
   // define event behaviour
   timeline_event_g_enter
     .on("click", function (d, i) {
-      if (globals.playback_mode === false) {
+      if (!globals.playback_mode) {
         return eventClickListener(tl_representation, unit_width, configurableTL, d, i);
       }
     })

--- a/src/configurableTL.js
+++ b/src/configurableTL.js
@@ -572,7 +572,9 @@ function initializeElements(timeline_container, data, duration, width, height, u
   // define event behaviour
   timeline_event_g_enter
     .on("click", function (d, i) {
-      return eventClickListener(tl_representation, unit_width, configurableTL, d, i);
+      if (globals.playback_mode === false) {
+        return eventClickListener(tl_representation, unit_width, configurableTL, d, i);
+      }
     })
     .on("mouseover", function (d) {
       return eventMouseOverListener(d, tl_representation, unit_width, configurableTL);

--- a/src/globals.js
+++ b/src/globals.js
@@ -116,7 +116,8 @@ function reset() {
     color_swap_target: 0,
     use_custom_palette: false,
     serverless: false,
-    socket: u
+    socket: u,
+    playback_mode: u
   }); // Defined in main.js
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -5491,9 +5491,6 @@ TimelineStoryteller.prototype.setPlaybackMode = function (isPlayback, addLog) {
     optionDiv.attr("class", "control_div onhover");
 
     d3.select(".introjs-hints").style("opacity", 0);
-    // Set read-only mode for annotation elements in playback mode
-    d3.selectAll(".annotation_control, .annotation_drag_area, .image_drag_area, .caption_drag_area")
-      .style("display", "none");
   } else {
     selectWithParent("#record_scene_btn").attr("class", "img_btn_enabled");
     optionDiv.attr("class", "control_div");
@@ -5501,10 +5498,10 @@ TimelineStoryteller.prototype.setPlaybackMode = function (isPlayback, addLog) {
     menuDiv.attr("class", "control_div");
 
     d3.select(".introjs-hints").style("opacity", 1);
-    // Remove read-only mode for annotations
-    d3.selectAll(".annotation_control, .annotation_drag_area, .image_drag_area, .caption_drag_area")
-      .style("display", "inline");
   }
+  // Set read-only mode for annotation elements in playback mode
+  d3.selectAll(".annotation_control, .annotation_drag_area, .image_drag_area, .caption_drag_area")
+    .style("display", isPlayback ? "none" : "");
 
   toggleElement(optionDiv, "top", 10);
   toggleElement(menuDiv, "left", 10);

--- a/src/main.js
+++ b/src/main.js
@@ -5491,6 +5491,9 @@ TimelineStoryteller.prototype.setPlaybackMode = function (isPlayback, addLog) {
     optionDiv.attr("class", "control_div onhover");
 
     d3.select(".introjs-hints").style("opacity", 0);
+    // Set read-only mode for annotation elements in playback mode
+    d3.selectAll(".annotation_control, .annotation_drag_area, .image_drag_area, .caption_drag_area")
+      .style("display", "none");
   } else {
     selectWithParent("#record_scene_btn").attr("class", "img_btn_enabled");
     optionDiv.attr("class", "control_div");
@@ -5498,6 +5501,9 @@ TimelineStoryteller.prototype.setPlaybackMode = function (isPlayback, addLog) {
     menuDiv.attr("class", "control_div");
 
     d3.select(".introjs-hints").style("opacity", 1);
+    // Remove read-only mode for annotations
+    d3.selectAll(".annotation_control, .annotation_drag_area, .image_drag_area, .caption_drag_area")
+      .style("display", "inline");
   }
 
   toggleElement(optionDiv, "top", 10);
@@ -5511,6 +5517,7 @@ TimelineStoryteller.prototype.setPlaybackMode = function (isPlayback, addLog) {
   selectWithParent().classed("playback_mode", isPlayback);
 
   this.playback_mode = isPlayback;
+  globals.playback_mode = this.playback_mode;
 
   if (typeof addLog === "undefined" || addLog) {
     logEvent("playback mode " + (isPlayback ? "on" : "off"), "playback");


### PR DESCRIPTION
Set read-only mode in playback state:
Annotations, captions, images cannot be dragged, added or deleted.
Annotations appear on mouse hover.
